### PR TITLE
disable xrender

### DIFF
--- a/files/etc/profile.d/ide.sh
+++ b/files/etc/profile.d/ide.sh
@@ -43,6 +43,7 @@ http_server() {
 }
 
 alias http-server=http_server # https://unix.stackexchange.com/a/168222
+alias java="java -Dsun.java2d.xrender=false"
 
 # X Window System
 export DISPLAY=":0"


### PR DESCRIPTION
GUI-based Java program don't seem to render properly. I think the libxrender version installed in the IDE is not compatible with what the latest Java is using. Disabling xrender seems to fix for now.

![rect](https://user-images.githubusercontent.com/7230211/104953003-96343300-5993-11eb-8c54-11dea4479fe1.png)